### PR TITLE
Fix exit replay gif regeneration bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ class GameApp {
         this.isGeneratingGif = false;
         this.userHasMovedAway = false;
         this.isStartingMode = false;
+        this.gifAlreadyGenerated = false; // Track if GIF has been generated for current game
 
         this.init();
     }
@@ -560,8 +561,10 @@ class GameApp {
                 this.returnToModeSelection();
             });
 
-            // Automatically generate and display GIF
-            this.generateAndShowGif();
+            // Automatically generate and display GIF only if not already generated
+            if (!this.gifAlreadyGenerated) {
+                this.generateAndShowGif();
+            }
         }
     }
 
@@ -636,6 +639,7 @@ class GameApp {
             });
             
             this.isGeneratingGif = false;
+            this.gifAlreadyGenerated = true; // Mark GIF as generated
             this.showGifInTopPanel(blob);
         } catch (e) {
             this.isGeneratingGif = false;
@@ -1198,6 +1202,7 @@ class GameApp {
         this.currentMode = null;
         this.isGeneratingGif = false;
         this.userHasMovedAway = false; // Reset for next game
+        this.gifAlreadyGenerated = false; // Reset GIF generation flag for new game
 
         // Show mode selection
         this.showModeSelection();


### PR DESCRIPTION
Prevent unnecessary GIF regeneration when exiting replay mode by tracking if a GIF has already been generated for the current game.

---
[Slack Thread](https://barnissan.slack.com/archives/C0930KPH3MW/p1759272682151489?thread_ts=1759272682.151489&cid=C0930KPH3MW)

<a href="https://cursor.com/background-agent?bcId=bc-700f0241-4ae1-4633-9f19-23675d0c7fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-700f0241-4ae1-4633-9f19-23675d0c7fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only auto-generate the game GIF on exit from replay if it hasn’t already been generated.
> 
> - **Replay/UI**:
>   - Gate auto GIF generation in `index.js::showGameOverOptions()` with `if (!this.gifAlreadyGenerated) this.generateAndShowGif();` to prevent regenerating an already-created GIF.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c52fec5518ca2cfb3f913e986287cd6ca0080e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->